### PR TITLE
stop the gsp from trying to encode the single quotes in the picker options to UTF-8.

### DIFF
--- a/grails-app/views/_popup.gsp
+++ b/grails-app/views/_popup.gsp
@@ -1,3 +1,4 @@
+<%@page defaultCodec="none" %>
 <r:require module="${function=='datepicker' ? 'jquery-ui' : 'timepicker'}" />
 <g:javascript>
     $('#${id}').${function}({


### PR DESCRIPTION
I had some problems in in Grails 2.3.4 with the plugin.  All the single quotes were encoded to UTF-8 characters and not rendering correctly.  This seemed to fix things,
