### PR TITLE
Fix java binding: correct config key

### DIFF
--- a/src/java/org/grails/plugins/jquerydatetimepicker/JqueryDateTimePickerEditorRegistrar.java
+++ b/src/java/org/grails/plugins/jquerydatetimepicker/JqueryDateTimePickerEditorRegistrar.java
@@ -13,8 +13,8 @@ public class JqueryDateTimePickerEditorRegistrar implements PropertyEditorRegist
     private GrailsApplication grailsApplication;
 
     public void registerCustomEditors(PropertyEditorRegistry reg) {
-        String timeFormat = get("datePicker.format.java.datetime", "dd/MM/yyyy HH:mm");
-        String dateFormat = get("datePicker.format.java.date", "dd/MM/yyyy");
+        String timeFormat = get("jqueryDateTimePicker.format.java.datetime", "dd/MM/yyyy HH:mm");
+        String dateFormat = get("jqueryDateTimePicker.format.java.date", "dd/MM/yyyy");
         reg.registerCustomEditor(Date.class, new JqueryDateTimePickerDateBinder(Arrays.asList(timeFormat, dateFormat)));
     }
 


### PR DESCRIPTION
In README and JqueryDateTimePickerTagLib.groovy the key is `jqueryDateTimePicker.format.java.datetime`
But in JqueryDateTimePickerEditorRegistrar the prefix was `datePicker.format.java.datetime`, so the date was formatted and parsed differently => binding did not work.
